### PR TITLE
Set publicPath in webpack config

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -7,6 +7,6 @@
     <div id="app"></div>
 
     <!-- <script src="http://localhost:8080/webpack-dev-server.js"></script> -->
-    <script src="./assets/js/bundle.js"></script>
+    <script src="/assets/bundle.js"></script>
   </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,8 +11,9 @@ const PATHS = {
 const config = {
   entry: PATHS.app + '/js/main.js',
   output: {
-    path: PATHS.build + '/assets/js',
+    path: PATHS.build + '/assets',
     filename: 'bundle.js',
+    publicPath: '/assets'
   },
   module: {
     loaders: [


### PR DESCRIPTION
@pauloelias I think you were serving your built files, hence no effect after reloading. This should fix it, but not 100% sure it's correct to set up paths like this. Maybe check out https://github.com/gaearon/react-transform-boilerplate or some webpack 2 fanciness?
